### PR TITLE
chore: add archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# ⚠️ ARCHIVED ⚠️
+
+Local now supports PhpStorm's [zero-config debugging](https://www.jetbrains.com/help/phpstorm/zero-configuration-debugging.html). 🎉
+
+See the [official docs on using Xdebug in Local with PhpStorm](https://localwp.com/help-docs/use-xdebug-in-local-with-phpstorm/).
+
 # Local Add-on: Xdebug + PhpStorm [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/getflywheel/local-addon-volumes/pulls/)
 
 ## Manual Installation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Local now supports PhpStorm's [zero-config debugging](https://www.jetbrains.com/help/phpstorm/zero-configuration-debugging.html). 🎉
 
-See the [official docs on using Xdebug in Local with PhpStorm](https://localwp.com/help-docs/use-xdebug-in-local-with-phpstorm/).
+See the [official docs on using Xdebug in Local with PhpStorm](https://localwp.com/help-docs/local-features/use-xdebug-in-local-with-phpstorm/).
 
 # Local Add-on: Xdebug + PhpStorm [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/getflywheel/local-addon-volumes/pulls/)
 


### PR DESCRIPTION
Adds archive notice ahead of archiving this repo.

Newer PHP/Xdebug in Local (PHP 7 or higher) now support PhpStorm's [zero-config debugging](https://www.jetbrains.com/help/phpstorm/zero-configuration-debugging.html).

We'll have a linked help doc — currently unpublished — explaining how this works in Local.

## Review notes

Preview new readme at https://github.com/getflywheel/local-addon-xdebug-phpstorm/tree/nc/LOC-5361/archive-phpstorm-addon?tab=readme-ov-file.